### PR TITLE
feat: add command to regenerate video thumbnails

### DIFF
--- a/cmd/thumbnail.go
+++ b/cmd/thumbnail.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/AlbinoDrought/creamy-videos/videostore"
+	"github.com/spf13/cobra"
+)
+
+var regenerateAllThumbnails = false
+
+type videoGetter func() []videostore.Video
+
+var thumbnailCommand = &cobra.Command{
+	Use:   "thumbnail [-a to regen all] [video ids]",
+	Short: "Regenerate thumbnail for given video, or all videos",
+	Run: func(cmd *cobra.Command, args []string) {
+		var getter videoGetter
+		// loop over all videos
+		if regenerateAllThumbnails {
+			currentOffset := uint(0)
+			limit := uint(100)
+			getter = func() []videostore.Video {
+				videos, err := app.repo.All(videostore.VideoFilter{}, limit, currentOffset)
+				if err != nil {
+					log.Fatalf("error fetching videos: %+v", err)
+				}
+				currentOffset += limit
+				return videos
+			}
+		} else {
+			// loop over selected ids
+			ids := make([]uint, len(args))
+			for i, arg := range args {
+				id, err := strconv.Atoi(arg)
+				if err != nil {
+					log.Fatalf("error converting to int: %+v", err)
+				}
+				ids[i] = uint(id)
+			}
+
+			getter = func() []videostore.Video {
+				if len(ids) == 0 {
+					return []videostore.Video{}
+				}
+
+				id := ids[0]
+				ids = ids[1:]
+
+				video, err := app.repo.FindById(id)
+				if err != nil {
+					log.Fatalf("error fetching video: %+v", err)
+				}
+
+				return []videostore.Video{video}
+			}
+		}
+
+		var videos []videostore.Video
+		for {
+			videos = getter()
+			if len(videos) == 0 {
+				break
+			}
+			for _, video := range videos {
+				_, err := videostore.GenerateThumbnail(video, app.repo, app.fs)
+				if err == nil {
+					log.Printf("generated thumbnail for %+v", video.ID)
+				} else {
+					log.Printf("failed to generate for %+v: %+v", video.ID, err)
+				}
+			}
+		}
+	},
+}
+
+func init() {
+	thumbnailCommand.Flags().BoolVarP(&regenerateAllThumbnails, "all", "a", false, "if true, regenerate _all_ thumbnails")
+
+	rootCmd.AddCommand(thumbnailCommand)
+}

--- a/videostore/thumbnail.go
+++ b/videostore/thumbnail.go
@@ -6,22 +6,21 @@ import (
 	"path"
 
 	"github.com/AlbinoDrought/creamy-videos/files"
+	"github.com/pkg/errors"
 )
 
-func eventuallyMakeThumbnail(video Video, repo VideoRepo, fs files.TransformedFileSystem) {
+func GenerateThumbnail(video Video, repo VideoRepo, fs files.TransformedFileSystem) (Video, error) {
 	thumbnailPath := path.Join(path.Dir(video.Source), "thumbnail.jpg")
 
 	videoStream, err := fs.Open(video.Source)
 	if err != nil {
-		log.Printf("failed to open video: %+v", err)
-		return
+		return video, errors.Wrap(err, "failed to open video")
 	}
 	defer videoStream.Close()
 
 	createdThumbnailStream, err := fs.Create(thumbnailPath)
 	if err != nil {
-		log.Printf("failed to create thumbnail: %+v", err)
-		return
+		return video, errors.Wrap(err, "failed to create thumbnail")
 	}
 	defer createdThumbnailStream.Close()
 
@@ -31,15 +30,22 @@ func eventuallyMakeThumbnail(video Video, repo VideoRepo, fs files.TransformedFi
 
 	err = cmd.Run()
 	if err != nil {
-		log.Printf("failed to run ffmpeg: %+v", err)
-		return
+		return video, errors.Wrap(err, "failed to run ffmpeg")
 	}
 
 	video.Thumbnail = thumbnailPath
 	_, err = repo.Save(video)
 
 	if err != nil {
-		log.Printf("failed to save video thumbnail: %+v", err)
-		return
+		return video, errors.Wrap(err, "failed to save video thumbnail to disk")
+	}
+
+	return video, nil
+}
+
+func eventuallyMakeThumbnail(video Video, repo VideoRepo, fs files.TransformedFileSystem) {
+	_, err := GenerateThumbnail(video, repo, fs)
+	if err != nil {
+		log.Printf("failed to make thumbnail thumbnail: %+v", err)
 	}
 }


### PR DESCRIPTION
`creamy-videos thumbnail -a`: regenerate all

or

`creamy-videos thumbnail 3 4 5`: regenerate for videos with IDs 3, 4, and 5