### PR TITLE
Fix node-related section of Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
 # install node
 before_install:
   - . $HOME/.nvm/nvm.sh # https://stackoverflow.com/a/43106527/3649573
-  - nvm install stable
-  - nvm use stable
+  - nvm install --lts
+  - nvm use --lts
   - psql -c "CREATE DATABASE creamy_videos;" -U postgres
   - psql -c "CREATE USER creamy WITH PASSWORD 'videos';" -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_install:
   - nvm use --lts
   - psql -c "CREATE DATABASE creamy_videos;" -U postgres
   - psql -c "CREATE USER creamy WITH PASSWORD 'videos';" -U postgres
+  # install cypress dependencies
+  - sudo apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 
 install:
   - go get -u github.com/gobuffalo/packr/v2/packr2


### PR DESCRIPTION
node-sass was failing in Travis build when being built on node v12 (current version at the time of this PR)

This PR changes the build to prefer LTS versions of node instead of current versions which is a hack but works for now™️  until packages are updated.