### PR TITLE
Fix redirect loop by replacing packr2 with an alternative solution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - sudo apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 
 install:
-  - go get -u github.com/gobuffalo/packr/v2/packr2
+  - go get github.com/GeertJohan/go.rice/rice
   - go get
   - cd ui && npm install && cd ..
 
@@ -39,7 +39,8 @@ before_script:
 
 script:
   - cd ui && npm run build && cd ..
-  - packr2 build
+  - cd cmd && rice embed-go && cd ..
+  - go build
   - ./creamy-videos serve &
   - sleep 2 # give it time to start
   - cd ui && npm run test:e2e -- --headless --url http://localhost:3000/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
 # install node
 before_install:
   - . $HOME/.nvm/nvm.sh # https://stackoverflow.com/a/43106527/3649573
-  - nvm install stable
-  - nvm use stable
+  - nvm install --lts
+  - nvm use --lts
   - psql -c "CREATE DATABASE creamy_videos;" -U postgres
   - psql -c "CREATE USER creamy WITH PASSWORD 'videos';" -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_install:
   - nvm use --lts
   - psql -c "CREATE DATABASE creamy_videos;" -U postgres
   - psql -c "CREATE USER creamy WITH PASSWORD 'videos';" -U postgres
+  # install cypress dependencies
+  - sudo apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 
 install:
   - go get -u github.com/gobuffalo/packr/v2/packr2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,16 +22,19 @@ COPY --from=SPA /ui/dist $GOPATH/src/github.com/AlbinoDrought/creamy-videos/ui/d
 # shove compressed source into SPA dist
 RUN cp /tmp/source.tar.gz ui/dist
 
+ENV CGO_ENABLED=0 \
+  GOOS=linux \
+  GOARCH=amd64
+
 # install dependencies
 RUN go get -d -v
-# install packr2 build too
-RUN go get -u github.com/gobuffalo/packr/v2/packr2
+# install go.rice buildtool
+RUN go get github.com/GeertJohan/go.rice/rice
 
-# build with packr2 to embed SPA
-RUN CGO_ENABLED=0 \
-  GOOS=linux \
-  GOARCH=amd64 \
-  packr2 build -a -installsuffix cgo -o /go/bin/creamy-videos
+# create embedded SPA files
+RUN cd cmd && rice embed-go
+# build full binary
+RUN go build -a -installsuffix cgo -o /go/bin/creamy-videos
 
 # start from ffmpeg for thumbnail gen
 FROM jrottenberg/ffmpeg:4.0-alpine

--- a/README.md
+++ b/README.md
@@ -4,18 +4,27 @@ The creamiest selfhosted tubesite
 
 ## Building
 
+### Without Docker
+
 ```
 # build SPA
 cd ui && npm install && npm run build
 
 # install go deps
 go get -d -v
-# install packr2 binary
-go get -u github.com/gobuffalo/packr/v2/packr2
+# install go.rice buildtool for asset embedding
+go get github.com/GeertJohan/go.rice/rice
 
-# build binary
-packr2 build
+# pack SPA for embedding
+cd cmd && rice embed-go && cd ..
+
+# build single-file creamy-videos.exe
+go build
 ```
+
+### With Docker
+
+`docker build -t albinodrought/creamy-videos .`
 
 ## Usage
 


### PR DESCRIPTION
I was implementing a new feature and found out that builds have been failing for a while, even without any code changes.

Half of these build failures were Node related, fixed in https://github.com/AlbinoDrought/creamy-videos/pull/15

The other half were from redirect loops occurring on `/`. This issue was also reported in the packr2 repo ([see description of this commit, I don't want to trigger more mentions](https://github.com/AlbinoDrought/creamy-videos/commit/f997ac7f3cb9db08e4991376ae4bbb7bf4f0b40e)). Tried setting up gomodules and locking packr2 to an older version but had no luck, so I'm swapping it out completely instead.

