### PR TITLE
Add some "read only" flags so we can boot non-modifiable instances

### DIFF
--- a/Dockerfile.readonly
+++ b/Dockerfile.readonly
@@ -24,25 +24,26 @@ COPY --from=SPA /ui/dist $GOPATH/src/github.com/AlbinoDrought/creamy-videos/ui/d
 # shove compressed source into SPA dist
 RUN cp /tmp/source.tar.gz ui/dist
 
-# install dependencies
-RUN go get -d -v
-# install packr2 build too
-RUN go get -u github.com/gobuffalo/packr/v2/packr2
-
-# build with packr2 to embed SPA
-RUN CGO_ENABLED=0 \
+ENV CGO_ENABLED=0 \
   GOOS=linux \
   GOARCH=amd64 \
-  packr2 build -a -installsuffix cgo -o /go/bin/creamy-videos
+  CREAMY_READ_ONLY=true
+
+# install dependencies
+RUN go get -d -v
+# install go.rice buildtool
+RUN go get github.com/GeertJohan/go.rice/rice
+
+# create embedded SPA files
+RUN cd cmd && rice embed-go
+# build full binary
+RUN go build -a -installsuffix cgo -o /go/bin/creamy-videos
 
 # start from ffmpeg for thumbnail gen
 FROM jrottenberg/ffmpeg:4.0-alpine
 
 # Copy our static executable
 COPY --from=builder /go/bin/creamy-videos /go/bin/creamy-videos
-
-# Mark as read only
-ENV CREAMY_READ_ONLY true
 
 # clear ffmpeg dockerfile cmd
 CMD []

--- a/Dockerfile.readonly
+++ b/Dockerfile.readonly
@@ -1,0 +1,49 @@
+### Same as the normal Dockerfile but with some read-only env vars thrown in.
+
+# Build SPA
+FROM albinodrought/node-alpine-gcc-make-ssh as SPA
+
+COPY ./ui /ui
+WORKDIR /ui
+
+RUN npm install --no-optional
+RUN VUE_APP_READ_ONLY=true npm run build
+
+# Build binary
+FROM golang:alpine as builder
+
+RUN apk update && apk add git
+COPY . $GOPATH/src/github.com/AlbinoDrought/creamy-videos
+WORKDIR $GOPATH/src/github.com/AlbinoDrought/creamy-videos
+
+# compress source for later downloading
+RUN tar -zcvf /tmp/source.tar.gz .
+
+# copy built SPA
+COPY --from=SPA /ui/dist $GOPATH/src/github.com/AlbinoDrought/creamy-videos/ui/dist
+# shove compressed source into SPA dist
+RUN cp /tmp/source.tar.gz ui/dist
+
+# install dependencies
+RUN go get -d -v
+# install packr2 build too
+RUN go get -u github.com/gobuffalo/packr/v2/packr2
+
+# build with packr2 to embed SPA
+RUN CGO_ENABLED=0 \
+  GOOS=linux \
+  GOARCH=amd64 \
+  packr2 build -a -installsuffix cgo -o /go/bin/creamy-videos
+
+# start from ffmpeg for thumbnail gen
+FROM jrottenberg/ffmpeg:4.0-alpine
+
+# Copy our static executable
+COPY --from=builder /go/bin/creamy-videos /go/bin/creamy-videos
+
+# Mark as read only
+ENV CREAMY_READ_ONLY true
+
+# clear ffmpeg dockerfile cmd
+CMD []
+ENTRYPOINT ["/go/bin/creamy-videos", "serve"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ CREAMY_POSTGRES_ADDRESS=localhost:5432 \
 
 - `CREAMY_POSTGRES_ADDRESS`: Postgres address including port, defaults to `localhost:5432`
 
+- `CREAMY_READ_ONLY`: if `true`, set the API to read-only mode and disable non-read-only routes
+
 (all following commands require the same env configuration)
 
 ### Migrating data from JSON to Postgres

--- a/cmd/helper_config.go
+++ b/cmd/helper_config.go
@@ -15,6 +15,7 @@ type appConfig struct {
 	PostgresAddress     string
 	PostgresDatabase    string
 	FilesystemKey       byte
+	ReadOnly            bool
 }
 
 func envDefault(name string, backup string) string {
@@ -37,5 +38,6 @@ func makeConfig() appConfig {
 		PostgresDatabase:    envDefault("CREAMY_POSTGRES_DATABASE", "postgres"),
 		PostgresAddress:     envDefault("CREAMY_POSTGRES_ADDRESS", "localhost:5432"),
 		FilesystemKey:       0x69, // hardcoded for now
+		ReadOnly:            envDefault("CREAMY_READ_ONLY", "false") == "true",
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -275,14 +275,18 @@ var serveCmd = &cobra.Command{
 			"/api/video/{id:[0-9]+}",
 			showVideoHandler(app),
 		).Methods("GET")
-		r.HandleFunc(
-			"/api/video/{id:[0-9]+}",
-			editVideoHandler(app),
-		).Methods("POST")
-		r.HandleFunc(
-			"/api/video/{id:[0-9]+}",
-			deleteVideoHandler(app),
-		).Methods("DELETE")
+
+		// disable impactful routes if in read-only mode
+		if !app.config.ReadOnly {
+			r.HandleFunc(
+				"/api/video/{id:[0-9]+}",
+				editVideoHandler(app),
+			).Methods("POST")
+			r.HandleFunc(
+				"/api/video/{id:[0-9]+}",
+				deleteVideoHandler(app),
+			).Methods("DELETE")
+		}
 
 		r.HandleFunc(
 			"/api/upload",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -280,16 +280,17 @@ var serveCmd = &cobra.Command{
 				"/api/video/{id:[0-9]+}",
 				editVideoHandler(app),
 			).Methods("POST")
+
 			r.HandleFunc(
 				"/api/video/{id:[0-9]+}",
 				deleteVideoHandler(app),
 			).Methods("DELETE")
-		}
 
-		r.HandleFunc(
-			"/api/upload",
-			uploadFileHandler(app),
-		)
+			r.HandleFunc(
+				"/api/upload",
+				uploadFileHandler(app),
+			)
+		}
 
 		r.PathPrefix(app.config.HTTPVideoDirectory).Handler(
 			http.StripPrefix(

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -9,7 +9,7 @@
         <router-link :to="{ name: 'home' }" class="item">
           Home
         </router-link>
-        <router-link :to="{ name: 'upload' }" class="item">
+        <router-link v-if="!readOnly" :to="{ name: 'upload' }" class="item">
           Upload
         </router-link>
 
@@ -61,6 +61,12 @@
 
 <script>
 export default {
+  computed: {
+    readOnly() {
+      return this.$store.getters.readOnly;
+    },
+  },
+
   data() {
     return {
       searchText: '',

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -4,11 +4,28 @@ import Meta from 'vue-meta';
 import Home from './views/Home.vue';
 import Watch from './views/Watch.vue';
 import Search from './views/Search.vue';
-import Upload from './views/Upload.vue';
-import Edit from './views/Edit.vue';
+const Upload = () => import('./views/Upload.vue');
+const Edit = () => import('./views/Edit.vue');
 
 Vue.use(Router);
 Vue.use(Meta);
+
+// impactful routes should be disabled if the app is built in read-only mode.
+const impactfulRoutes = process.env.VUE_APP_READ_ONLY
+  ? []
+  : [
+      {
+        path: '/edit/:id',
+        name: 'edit',
+        component: Edit,
+        props: true,
+      },
+      {
+        path: '/upload',
+        name: 'upload',
+        component: Upload,
+      },
+    ];
 
 export default new Router({
   mode: 'history',
@@ -32,17 +49,7 @@ export default new Router({
       component: Watch,
       props: true,
     },
-    {
-      path: '/edit/:id',
-      name: 'edit',
-      component: Edit,
-      props: true,
-    },
-    {
-      path: '/upload',
-      name: 'upload',
-      component: Upload,
-    },
+    ...impactfulRoutes,
     {
       path: '/search',
       name: 'search',

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -68,6 +68,11 @@ const fakePromiseDelay = (delay = 0) => new Promise((resolve) => {
 */
 
 export default new Vuex.Store({
+  getters: {
+    readOnly() {
+      return process.env.VUE_APP_READ_ONLY;
+    },
+  },
   actions: {
     videos(context, params = {}) {
       return client.get('/api/video', { params })

--- a/ui/src/views/Watch.vue
+++ b/ui/src/views/Watch.vue
@@ -19,17 +19,19 @@
             <i class="download icon" />
             Download
           </a>
-          <confirm-button class="ui basic red icon delete button" @confirm="deleteVideo">
-            <i class="trash icon" />
-            Delete
-          </confirm-button>
-          <router-link
-            class="ui basic yellow icon edit button"
-            :to="{ name: 'edit', params: { id: video.id } }"
-          >
-            <i class="edit icon" />
-            Edit
-          </router-link>
+          <template v-if="!readOnly">
+            <confirm-button class="ui basic red icon delete button" @confirm="deleteVideo">
+              <i class="trash icon" />
+              Delete
+            </confirm-button>
+            <router-link
+              class="ui basic yellow icon edit button"
+              :to="{ name: 'edit', params: { id: video.id } }"
+            >
+              <i class="edit icon" />
+              Edit
+            </router-link>
+          </template>
         </div>
         <div aria-label="Video Tags" class="tags">
           <router-link
@@ -52,6 +54,11 @@ import loadVideoById from './loadVideoById';
 export default {
   components: {
     ConfirmButton,
+  },
+  computed: {
+    readOnly() {
+      return this.$store.getters.readOnly;
+    },
   },
   mixins: [
     loadVideoById,


### PR DESCRIPTION
There's no built-in account or authorization support right now and it's not a priority for me. I was previously enforcing authorization with reverse proxy rules but this didn't stop things like "Upload", "Edit", or "Delete" from brokenly appearing on the UI.

This change adds two new env vars:

- `VUE_APP_READ_ONLY`: if this is set when the SPA is built, all "impactful" actions will be hidden from the user
- `CREAMY_READ_ONLY=true`: if this is set when `creamy-videos` is started, no "impactful" API routes will be accessible