### PR TITLE
Reduce upload form eyebleed

### DIFF
--- a/ui/src/views/Upload.vue
+++ b/ui/src/views/Upload.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="upload ui text container">
-    <div class="ui inverted form">
+    <div class="ui form">
       <div class="ui field">
         <label>Title</label>
         <input
@@ -130,11 +130,23 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-div.upload {
-  color: rgb(171, 171, 171);
+$form-text-color: rgb(171, 171, 171);
 
-  & .field>label {
-    color: rgb(171, 171, 171);
+div.upload {
+  color: $form-text-color;
+
+  & .field {
+    &>input, &>textarea {
+      // intended to override semantic-ui defaults:
+      @at-root &, &:focus {
+        background-color: rgba(255, 255, 255, 0.1);
+        color: white;
+      }
+    }
+
+    &>label {
+      color: $form-text-color;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/852873/65936346-38ac5980-e3d1-11e9-994b-cc9c96b8f548.png)

After:

![image](https://user-images.githubusercontent.com/852873/65936391-45c94880-e3d1-11e9-9ea4-96c6182a8b73.png)

(I'm assuming the out-of-place white textarea control is because of my setup)