### PR TITLE
Fix linting issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 before_script:
   - go vet
-  - cd ui && npm run lint && cd ..
+  - cd ui && npm run lint -- --no-fix && cd ..
 
 script:
   - cd ui && npm run build && cd ..

--- a/ui/src/components/SemanticProgressBar.vue
+++ b/ui/src/components/SemanticProgressBar.vue
@@ -18,7 +18,7 @@ export default {
       return (this.progressCurrent / this.progressMax) * 100;
     },
     humanizedProgressPercentage() {
-      return Math.round(this.progressPercentage) + '%';
+      return `${Math.round(this.progressPercentage)}%`;
     },
   },
 

--- a/ui/src/components/SortDropdown.vue
+++ b/ui/src/components/SortDropdown.vue
@@ -32,9 +32,7 @@ export default {
     value: {
       type: String,
       required: false,
-      default: () => {
-        return sortOptions[0].key;
-      },
+      default: () => sortOptions[0].key,
     },
     fluid: {
       type: Boolean,

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -3,6 +3,7 @@ import Router from 'vue-router';
 import Meta from 'vue-meta';
 import Watch from './views/Watch.vue';
 import Search from './views/Search.vue';
+
 const Upload = () => import('./views/Upload.vue');
 const Edit = () => import('./views/Edit.vue');
 
@@ -10,21 +11,21 @@ Vue.use(Router);
 Vue.use(Meta);
 
 // impactful routes should be disabled if the app is built in read-only mode.
-const impactfulRoutes = process.env.VUE_APP_READ_ONLY
-  ? []
-  : [
-      {
-        path: '/edit/:id',
-        name: 'edit',
-        component: Edit,
-        props: true,
-      },
-      {
-        path: '/upload',
-        name: 'upload',
-        component: Upload,
-      },
-    ];
+const impactfulRoutes = [
+  {
+    path: '/edit/:id',
+    name: 'edit',
+    component: Edit,
+    props: true,
+  },
+  {
+    path: '/upload',
+    name: 'upload',
+    component: Upload,
+  },
+];
+
+const enabledImpactfulRoutes = process.env.VUE_APP_READ_ONLY ? [] : impactfulRoutes;
 
 export default new Router({
   mode: 'history',
@@ -55,7 +56,7 @@ export default new Router({
       component: Watch,
       props: true,
     },
-    ...impactfulRoutes,
+    ...enabledImpactfulRoutes,
     {
       path: '/search',
       name: 'search',

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -79,10 +79,20 @@ export default new Vuex.Store({
         .then(resp => resp.data);
     },
     tagged({ dispatch }, { tags, page = 1, sortOption = {} }) {
-      return dispatch('videos', { tags, page, sort_field: sortOption.sortField, sort_direction: sortOption.sortDirection });
+      return dispatch('videos', {
+        tags,
+        page,
+        sort_field: sortOption.sortField,
+        sort_direction: sortOption.sortDirection,
+      });
     },
     filtered({ dispatch }, { filter, page = 1, sortOption = {} }) {
-      return dispatch('videos', { filter, page, sort_field: sortOption.sortField, sort_direction: sortOption.sortDirection });
+      return dispatch('videos', {
+        filter,
+        page,
+        sort_field: sortOption.sortField,
+        sort_direction: sortOption.sortDirection,
+      });
     },
     video(context, id) {
       return client.get(`/api/video/${id}`).then(resp => resp.data);

--- a/ui/src/views/Search.vue
+++ b/ui/src/views/Search.vue
@@ -76,23 +76,19 @@ export default {
         });
     },
     actuallyGetVideos() {
-      return this.mode === 'tags'
-        ? this.$store.dispatch(
-            'tagged', 
-            {
-              tags: this.tags,
-              page: this.pageToFetch,
-              sortOption: this.sortOption,
-            }
-          )
-        : this.$store.dispatch(
-          'filtered', 
-          { 
-            filter: this.text, 
-            page: this.pageToFetch,
-            sortOption: this.sortOption,
-          }
-        );
+      if (this.mode === 'tags') {
+        return this.$store.dispatch('tagged', {
+          tags: this.tags,
+          page: this.pageToFetch,
+          sortOption: this.sortOption,
+        });
+      }
+
+      return this.$store.dispatch('filtered', {
+        filter: this.text,
+        page: this.pageToFetch,
+        sortOption: this.sortOption,
+      });
     },
     handleInfinite(state) {
       this.infinitelyLoadVideos().then((newVideos) => {

--- a/ui/src/views/Upload.vue
+++ b/ui/src/views/Upload.vue
@@ -37,7 +37,7 @@
           @change="handleFileChange"
         >
       </div>
-      
+
       <semantic-progress-bar
         v-if="loading && progressMax > 0"
         class="inverted active"
@@ -113,7 +113,7 @@ export default {
             },
           },
         });
-        
+
         this.$router.push({
           name: 'watch',
           params: {

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -24,7 +24,7 @@ module.exports = {
     appleMobileWebAppStatusBarStyle: 'black',
     iconPaths: {
       appleTouchIcon: 'icons/icon-152x152.png',
-      msTileImage: 'icons/icon-144x144.png'
+      msTileImage: 'icons/icon-144x144.png',
     },
     workboxOptions: {
       skipWaiting: true,
@@ -44,5 +44,5 @@ module.exports = {
         },
       }],
     },
-  }
+  },
 };


### PR DESCRIPTION
`npm run lint` was used during CI, but it had autofix mode enabled by default so a bunch of code that triggered linter errors was checked in.

This PR fixes those errors and disables autofixing during CI.

(I didn't like the indentation the linter used when it autofixed calls performed as part of a ternary statement, so I have rejiggled them)