### PR TITLE
fix: force `appearance: textarea` to prevent resize control from bein…

### DIFF
--- a/ui/src/views/Upload.vue
+++ b/ui/src/views/Upload.vue
@@ -144,6 +144,11 @@ div.upload {
       }
     }
 
+    &>textarea {
+      // fix a weird issue where the drag-to-resize component was appearing with a white background:
+      appearance: textarea;
+    }
+
     &>label {
       color: $form-text-color;
     }


### PR DESCRIPTION
…g eye-bleed white

This issue was noted in #25:

> ![](https://user-images.githubusercontent.com/852873/65936391-45c94880-e3d1-11e9-9ea4-96c6182a8b73.png)
> 
> (I'm assuming the out-of-place white textarea control is because of my setup)

This issue affects multiple browsers across multiple personal devices. Removing the `appearance` attribute applied by semantic-ui seems to fix this:

![image](https://user-images.githubusercontent.com/852873/66096957-85b73980-e551-11e9-8361-52e4bb581a59.png)
