### PR TITLE
refactor: remove `Upload` from `videostore.Repository`

### DIFF
--- a/cmd/helper_app.go
+++ b/cmd/helper_app.go
@@ -27,7 +27,7 @@ func (instance application) makePostgresRepo() videostore.VideoRepo {
 	})
 	// db never closed
 
-	return videostore.NewPostgresVideoRepo(*db, instance.fs)
+	return videostore.NewPostgresVideoRepo(*db)
 }
 
 func makeApp(cfg appConfig) (instance application) {

--- a/videostore/thumbnail.go
+++ b/videostore/thumbnail.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -117,11 +116,4 @@ func generateThumbnailUsingTemporaryFile(video Video, fs files.FileSystem) (Vide
 	video.Thumbnail = finalThumbnailPath
 
 	return video, nil
-}
-
-func eventuallyMakeThumbnail(video Video, repo VideoRepo, fs files.FileSystem) {
-	_, err := GenerateThumbnail(video, repo, fs)
-	if err != nil {
-		log.Printf("failed to make thumbnail: %+v", err)
-	}
 }

--- a/videostore/video.go
+++ b/videostore/video.go
@@ -2,7 +2,6 @@ package videostore
 
 import (
 	"errors"
-	"io"
 )
 
 const SortDirectionAscending = "asc"
@@ -70,7 +69,6 @@ func (video Video) Exists() bool {
 }
 
 type VideoRepo interface {
-	Upload(video Video, reader io.Reader) (Video, error)
 	Save(video Video) (Video, error)
 	FindById(id uint) (Video, error)
 	All(filter VideoFilter, limit uint, offset uint) ([]Video, error)

--- a/videostore/video_json.go
+++ b/videostore/video_json.go
@@ -4,12 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
-	"os"
-	"path"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -57,30 +53,6 @@ func (repo *dummyVideoRepo) makeID() uint {
 	defer repo.idLock.Unlock()
 	repo.id = repo.id + 1
 	return repo.id
-}
-
-func (repo *dummyVideoRepo) Upload(video Video, reader io.Reader) (Video, error) {
-	video.Thumbnail = ""
-	video.Source = ""
-	video, err := repo.Save(video)
-
-	if err != nil {
-		return video, err
-	}
-
-	rootDir := strconv.Itoa(int(video.ID))
-	if _, err := repo.fs.Stat(rootDir); repo.fs.IsNotExist(err) {
-		repo.fs.MkdirAll(rootDir, os.ModePerm)
-	}
-
-	videoPath := path.Join(rootDir, "video"+path.Ext(video.OriginalFileName))
-
-	files.PipeTo(repo.fs, videoPath, reader)
-
-	video.Source = videoPath
-	go eventuallyMakeThumbnail(video, repo, repo.fs)
-
-	return repo.Save(video)
 }
 
 func (repo *dummyVideoRepo) dumpToDisk() {

--- a/videostore/video_json.go
+++ b/videostore/video_json.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/AlbinoDrought/creamy-videos/files"
-	"github.com/pkg/errors"
 )
 
 // dummyVideoRepo stores models to a local JSON file
@@ -95,24 +93,6 @@ func (repo *dummyVideoRepo) Delete(video Video) error {
 	// soft delete
 	repo.videos[index] = Video{}
 	repo.dumpToDisk()
-
-	_, err := repo.fs.Stat(video.Source)
-	if !repo.fs.IsNotExist(err) {
-		// video exists, attempt to delete
-		err = repo.fs.Remove(video.Source)
-		if err != nil {
-			log.Print(errors.Wrap(err, "failed to remove video from disk"))
-		}
-	}
-
-	_, err = repo.fs.Stat(video.Thumbnail)
-	if !repo.fs.IsNotExist(err) {
-		// thumbnail exists, attempt to delete
-		err = repo.fs.Remove(video.Thumbnail)
-		if err != nil {
-			log.Print(errors.Wrap(err, "failed to remove thumbnail from disk"))
-		}
-	}
 
 	return nil
 }

--- a/videostore/video_pgsql.go
+++ b/videostore/video_pgsql.go
@@ -116,23 +116,5 @@ func (repo *postgresVideoRepo) Delete(video Video) error {
 		return errors.Wrap(err, "failed to delete from db")
 	}
 
-	_, err = repo.fs.Stat(video.Source)
-	if !repo.fs.IsNotExist(err) {
-		// video exists, attempt to delete
-		err = repo.fs.Remove(video.Source)
-		if err != nil {
-			log.Print(errors.Wrap(err, "failed to remove video from disk"))
-		}
-	}
-
-	_, err = repo.fs.Stat(video.Thumbnail)
-	if !repo.fs.IsNotExist(err) {
-		// thumbnail exists, attempt to delete
-		err = repo.fs.Remove(video.Thumbnail)
-		if err != nil {
-			log.Print(errors.Wrap(err, "failed to remove thumbnail from disk"))
-		}
-	}
-
 	return nil
 }

--- a/videostore/video_pgsql.go
+++ b/videostore/video_pgsql.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/AlbinoDrought/creamy-videos/files"
 	"github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
 )
@@ -15,10 +14,9 @@ import (
 // postgresVideoRepo stores models to a Postgres DB
 type postgresVideoRepo struct {
 	db pg.DB
-	fs files.FileSystem
 }
 
-func NewPostgresVideoRepo(db pg.DB, fs files.FileSystem) *postgresVideoRepo {
+func NewPostgresVideoRepo(db pg.DB) *postgresVideoRepo {
 	err := db.CreateTable((*Video)(nil), &orm.CreateTableOptions{
 		IfNotExists: true,
 	})
@@ -28,7 +26,6 @@ func NewPostgresVideoRepo(db pg.DB, fs files.FileSystem) *postgresVideoRepo {
 
 	return &postgresVideoRepo{
 		db,
-		fs,
 	}
 }
 


### PR DESCRIPTION
Code for this is duplicated between the two current stores and probably makes more sense to shove elsewhere anyways