### PR TITLE
Keep alive the search and home pages

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -62,7 +62,10 @@
         <sort-dropdown :fluid="true" v-model="sortKey" />
       </div>
 
-      <router-view :key="searchKey" />
+      <keep-alive>
+        <router-view :key="searchKey" v-if="$route.meta.keepAlive" />
+      </keep-alive>
+      <router-view :key="searchKey" v-if="!$route.meta.keepAlive" />
     </div>
   </div>
 </template>

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -49,6 +49,9 @@ export default new Router({
         sort: route.query.sort,
         title: 'Home',
       }),
+      meta: {
+        keepAlive: true,
+      },
     },
     {
       path: '/watch/:id',
@@ -63,6 +66,7 @@ export default new Router({
       component: Search,
       meta: {
         sortable: true,
+        keepAlive: true,
       },
       props: route => ({
         page: parseInt(route.query.page, 10) || 1,


### PR DESCRIPTION
Common issue before this change:

1. Browse through very long list of videos
2. Click a video to watch it
3. Press browser back button to go back to the list
4. You're all the way back at the top of the list

After this change:

1. Browse through very long list of videos
2. Click a video to watch it
3. Press browser back button to go back to the list
4. You're right where you left off

This branch has been released as `albinodrought/creamy-videos:experimental-ui-keepalive` for testing